### PR TITLE
Remove job posting for Rails developer

### DIFF
--- a/app/views/jobs/index.html.erb
+++ b/app/views/jobs/index.html.erb
@@ -1,27 +1,5 @@
 <div>
-  <h2>Experienced Rails Developer</h2>
+  <p>There are no positions available at this time.</p>
 
-  <p>Sassafras Tech Collective is looking for an experienced Ruby on Rails developer to work on exciting, high-impact projects related to social justice. We need someone who is able to jump in and get started. We are ideally looking for someone who has experience with:</p>
-  <ul>
-    <li>Object-oriented design</li>
-    <li>Testing</li>
-    <li>Agile processes</li>
-    <li>Working independently</li>
-  </ul>
-
-  <p>Sassafras Tech Collective is a worker-owned tech consulting cooperative based in Ann Arbor, MI. We research, design, and develop technology projects that focus on social change and social justice.</p>
-
-  <p>Some of our projects include work that focuses on:</p>
-  <ul>
-    <li>Election observation systems in the Global South</li>
-    <li>Worker co-op micro loans in disadvantaged communities</li>
-    <li>Ending gender/LGBTQ-based violence</li>
-    <li>Health and disadvantaged communities</li>
-  </ul>
-
-  <p>As an employee of Sassafras, you will have the opportunity to become a full worker-owner after an initial candidacy period of 6-12 months. We offer benefits such as generous paid time off, health insurance, flexible hours, and rad projects.</p>
-
-  <p>We have a preference for folks who are local to Ann Arbor, Michigan, but we are open to talking to remote folks as well. People traditionally underrepresented in the tech industry, especially women, LGBTQ folks, and men of color are strongly encouraged to apply.</p>
-
-  <p>If you are interested, please send a resume and code sample to <a href="contact">info@sassafras.coop</a>. We look forward to hearing from you!</p>
+  <p>The Experienced Rails Developer position has been filled.</p>
 </div>


### PR DESCRIPTION
Once the position is removed, this page does not have a lot of content, so visually it doesn't look great. Another alternative is to remove the page from the menu until it is needed in the future. I'd prefer to keep the jobs page available on the site (though not necessarily in the menu) in case people are looking for it.